### PR TITLE
Update VST2 SDK refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 build/
-VST3 SDK
+VST2_SDK

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(HAVE_ZYNAYUMI AND LVTK_FOUND)
   set(HAVE_LVTK 1)
 endif(HAVE_ZYNAYUMI AND LVTK_FOUND)
 
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/VST3 SDK/public.sdk/source/vst2.x/audioeffectx.h")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/VST2_SDK/public.sdk/source/vst2.x/audioeffectx.h")
   set(HAVE_VST 1)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -47,24 +47,30 @@ distribution, otherwise, have a look at http://dssi.sourceforge.net/.
 
 ## VST Support
 
-For VST support, you need an old SDK as recent ones no longer support
-VST2.  You may find one
-[here](https://www.steinberg.net/sdk_downloads/vstsdk366_27_06_2016_build_61.zip).
-If the link no longer works let me know, hopefully I have a copy of
-it.
+For VST2 support, you need a copy of the old VST36 SDK as recent ones don't come with VST2 headers anymore.
 
-Just unzip the SDK under the zynayumi root folder.
+[vstsdk367_03_03_2017_build_352](https://www.steinberg.net/sdk_downloads/vstsdk367_03_03_2017_build_352.zip) is the last known one still available.
 
-Under GNU/Linux 64-bit, you may need to comment out some code in
+Just unzip the VST2_SDK folder to the Zynayumi root folder.
 
-```
-pluginterfaces/vst2.x/aeffect.h
-```
+Under GNU/Linux 64-bit, you may need to do this patch first:
 
-specifically all definitions of `VSTCALLBACK` except the last one
-
-```
-#define VSTCALLBACK
+```diff
+--- VST2_SDK/pluginterfaces/vst2.x/aeffect.h
++++ VST2_SDK/pluginterfaces/vst2.x/aeffect.h
+@@ -66,7 +66,11 @@
+        #pragma options push -a8
+ #elif defined(__GNUC__)
+     #pragma pack(push,8)
+-    #define VSTCALLBACK __cdecl
++    #if defined(__linux__)
++        #define VSTCALLBACK
++    #else
++        #define VSTCALLBACK __cdecl
++    #endif
+ #elif defined(WIN32) || defined(__FLAT__) || defined CBUILDER
+        #pragma pack(push)
+        #pragma pack(8)
 ```
 
 ## LV2 Support

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,13 +22,13 @@ endif (HAVE_DSSI)
 
 # VST plugin
 if (HAVE_VST)
-  include_directories("${PROJECT_SOURCE_DIR}/VST3 SDK")
+  include_directories("${PROJECT_SOURCE_DIR}/VST2_SDK")
 
   add_library(zynayumi-vst SHARED
     vstzynayumi
-    "${PROJECT_SOURCE_DIR}/VST3 SDK/public.sdk/source/vst2.x/vstplugmain"
-    "${PROJECT_SOURCE_DIR}/VST3 SDK/public.sdk/source/vst2.x/audioeffect"
-    "${PROJECT_SOURCE_DIR}/VST3 SDK/public.sdk/source/vst2.x/audioeffectx")
+    "${PROJECT_SOURCE_DIR}/VST2_SDK/public.sdk/source/vst2.x/vstplugmain"
+    "${PROJECT_SOURCE_DIR}/VST2_SDK/public.sdk/source/vst2.x/audioeffect"
+    "${PROJECT_SOURCE_DIR}/VST2_SDK/public.sdk/source/vst2.x/audioeffectx")
 
   target_link_libraries(zynayumi-vst
     zynayumi)


### PR DESCRIPTION
This line was causing build to fail when extracting the mentioned VST SDK 366 to the project folder:
https://github.com/ngeiswei/zynayumi/blob/ac2cbc1265e6179d835b0cf61b3d2082f49f10c4/src/vstzynayumi.cpp#L27
It didn't include the right directory structure like this file https://github.com/ngeiswei/zynayumi/blob/ac2cbc1265e6179d835b0cf61b3d2082f49f10c4/src/vstzynayumi.hpp#L28

so I've updated the link in the readme to the last known SDK with VST2 headers `vstsdk367_03_03_2017_build_352.zip` which has the directory structure the source file expects and updated the cmake paths.

and now Zynayumi should build out of the box (I've only tested Linux) after extracting the SDK from the above link.